### PR TITLE
WiP: Add primary address properties to certain user contexts (CIRC-1789)

### DIFF
--- a/src/main/java/org/folio/circulation/domain/User.java
+++ b/src/main/java/org/folio/circulation/domain/User.java
@@ -122,6 +122,16 @@ public class User {
       .orElse(null);
   }
 
+  public JsonObject getPrimaryAddress() {
+    JsonObject personal = getObjectProperty(representation, PERSONAL_PROPERTY_NAME);
+    val addresses = toStream(personal, "addresses");
+    return addresses
+      .filter(Objects::nonNull)
+      .filter(address -> Objects.equals(getBooleanProperty(address, "primaryAddress"), true))
+      .findFirst()
+      .orElse(null);
+  }
+
   public PatronGroup getPatronGroup() {
     return patronGroup;
   }

--- a/src/main/java/org/folio/circulation/domain/notice/combiner/LoanNoticeContextCombiner.java
+++ b/src/main/java/org/folio/circulation/domain/notice/combiner/LoanNoticeContextCombiner.java
@@ -22,7 +22,7 @@ public class LoanNoticeContextCombiner implements NoticeContextCombiner {
       .collect(collectingAndThen(
         Collectors.toList(),
         contexts -> new JsonObject()
-          .put("user", createUserContext(events.iterator().next().getUser()))
+          .put("user", createUserContext(events.iterator().next().getUser()).asJson())
           .put("loans", contexts)
       ));
   }


### PR DESCRIPTION
Adds user's primary address properties to user context when injected into "loan notice context" and "request notice context".

In staff slip context it's still the properties of a specific address type, not necessarily the primary address of the user, that are inserted. 

Address type ID is only available as a UUID so far.  