### PR TITLE
CIRC-1848 Add missing permission for add-info endpoint to work

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -2095,6 +2095,7 @@
       "description": "to reduce X-Okapi-Token size",
       "subPermissions": [
         "circulation-storage.loans.item.get",
+        "circulation-storage.loans.item.put",
         "circulation.internal.fetch-items",
         "users.item.get",
         "pubsub.publish.post"


### PR DESCRIPTION
CIRC-1848 Add missing permission for add-info endpoint to work

## Purpose
Change needed for endpoint add-info to work with visible permissions 

## Approach
circulation-storage.loans.item.put permission added as subPermission to circulation.loans.add-info.post for endpoint to work
