### PR TITLE
Apply relevance logic, reminders (CIRC-1527)

### DIFF
--- a/src/main/java/org/folio/circulation/domain/notice/schedule/LoanScheduledNoticeHandler.java
+++ b/src/main/java/org/folio/circulation/domain/notice/schedule/LoanScheduledNoticeHandler.java
@@ -138,7 +138,7 @@ public class LoanScheduledNoticeHandler extends ScheduledNoticeHandler {
       .thenApply(mapResult(context::withLostItemFeesForAgedToLostNoticeExist));
   }
 
-  private boolean dueDateNoticeIsNotRelevant(ScheduledNoticeContext context) {
+  protected boolean dueDateNoticeIsNotRelevant(ScheduledNoticeContext context) {
     Loan loan = context.getLoan();
     ZonedDateTime dueDate = loan.getDueDate();
     String loanId = loan.getId();


### PR DESCRIPTION
Reuse overdue notice relevance logic to discard a scheduled notice, for example if the loan is closed.

Retry PR due to unrelated concurrent-modification exception in previous attempt.