### PR TITLE
Merge CIRC-1970 don't create zero account to Circ 1920 reminders on closed days

### DIFF
--- a/src/main/java/org/folio/circulation/domain/policy/OverdueFinePolicyRemindersPolicy.java
+++ b/src/main/java/org/folio/circulation/domain/policy/OverdueFinePolicyRemindersPolicy.java
@@ -135,5 +135,9 @@ public class OverdueFinePolicyRemindersPolicy {
       return (capitalized.endsWith("s") ? capitalized : capitalized + "s");
     }
 
+    public boolean hasZeroFee () {
+      return reminderFee.doubleValue() == 0.0;
+    }
+
   }
 }

--- a/src/test/java/api/loans/CheckOutByBarcodeTests.java
+++ b/src/test/java/api/loans/CheckOutByBarcodeTests.java
@@ -1607,7 +1607,8 @@ class CheckOutByBarcodeTests extends APITests {
     final IndividualResource steve = usersFixture.steve();
 
     FakePubSub.setFailPublishingWithBadRequestError(true);
-    checkOutFixture.attemptCheckOutByBarcode(200,
+    // since ITEM_CHECKED_OUT event is published asynchronously it doesn't affect check-out response
+    checkOutFixture.checkOutByBarcode(
       new CheckOutByBarcodeRequestBuilder()
         .forItem(smallAngryPlanet)
         .to(steve)

--- a/src/test/java/api/loans/ReminderFeeTests.java
+++ b/src/test/java/api/loans/ReminderFeeTests.java
@@ -107,7 +107,7 @@ class ReminderFeeTests extends APITests {
   }
 
   @Test
-  void willSendThreeRemindersAndCreateThreeAccountsThenStop() {
+  void willSendThreeRemindersAndCreateTwoAccountsThenStop() {
 
     final IndividualResource response = checkOutFixture.checkOutByBarcode(
       new CheckOutByBarcodeRequestBuilder()
@@ -137,7 +137,8 @@ class ReminderFeeTests extends APITests {
     verifyNumberOfSentNotices(2);
     verifyNumberOfPublishedEvents(NOTICE, 2);
     verifyNumberOfPublishedEvents(NOTICE_ERROR, 0);
-    waitAtMost(1, SECONDS).until(accountsClient::getAll, hasSize(2));
+    // Second reminder has zero fee, don't create account
+    waitAtMost(1, SECONDS).until(accountsClient::getAll, hasSize(1));
 
     ZonedDateTime thirdRunTime = dueDate.plusMinutes(6);
     scheduledNoticeProcessingClient.runScheduledDigitalRemindersProcessing(thirdRunTime);
@@ -146,7 +147,7 @@ class ReminderFeeTests extends APITests {
     verifyNumberOfSentNotices(3);
     verifyNumberOfPublishedEvents(NOTICE, 3);
     verifyNumberOfPublishedEvents(NOTICE_ERROR, 0);
-    waitAtMost(1, SECONDS).until(accountsClient::getAll, hasSize(3));
+    waitAtMost(1, SECONDS).until(accountsClient::getAll, hasSize(2));
 
     ZonedDateTime fourthRunTime = dueDate.plusMinutes(8);
     scheduledNoticeProcessingClient.runScheduledDigitalRemindersProcessing(fourthRunTime);
@@ -155,7 +156,7 @@ class ReminderFeeTests extends APITests {
     verifyNumberOfSentNotices(3);
     verifyNumberOfPublishedEvents(NOTICE, 3);
     verifyNumberOfPublishedEvents(NOTICE_ERROR, 0);
-    waitAtMost(1, SECONDS).until(accountsClient::getAll, hasSize(3));
+    waitAtMost(1, SECONDS).until(accountsClient::getAll, hasSize(2));
   }
 
   @Test

--- a/src/test/java/api/support/fixtures/OverdueFinePoliciesFixture.java
+++ b/src/test/java/api/support/fixtures/OverdueFinePoliciesFixture.java
@@ -111,7 +111,7 @@ public class OverdueFinePoliciesFixture {
       .withAddedReminderEntry(
         1,"minute",1.50,
         "Email",FIRST_REMINDER_TEMPLATE_ID.toString())
-      .withAddedReminderEntry(1, "minute", 2.00,
+      .withAddedReminderEntry(1, "minute", 0.00,
         "Email", SECOND_REMINDER_TEMPLATE_ID.toString())
       .withAddedReminderEntry(1,"minute", 2.15,
         "Email", THIRD_REMINDER_TEMPLATE_ID.toString());


### PR DESCRIPTION
These branches have diverged. CIRC-1970 will go into upstream master first (bug-fix before release). Eventually there will be merge conflicts to resolve when updating CIRC-1920 from upstream master. Right now they are merge and resolved as well, just to be able to test both on orchid-dev, deployment branch. 